### PR TITLE
bitrate compression on api 31 and above

### DIFF
--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/utils/CompressorUtils.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/utils/CompressorUtils.kt
@@ -80,6 +80,7 @@ object CompressorUtils {
             setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, iFrameInterval)
             // expected bps
             setInteger(MediaFormat.KEY_BIT_RATE, newBitrate)
+            setInteger(MediaFormat.KEY_BITRATE_MODE, MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR)
 
             if (Build.VERSION.SDK_INT > 23) {
 


### PR DESCRIPTION
set bitrate mode to CBR when creating output file parameters.
on api 31 and above default value is set to VBR which prevents quality loss on encoding. more on [MediaCodec](https://developer.android.com/reference/android/media/MediaCodec#qualityFloor)
this will probably solve issues #137  , #135 