### PR TITLE
Fixes a crash when the user tries a video with malformed bitrate information

### DIFF
--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
@@ -94,9 +94,15 @@ object Compressor {
             )
         }
 
-        var rotation = rotationData.toInt()
-        val bitrate = bitrateData.toInt()
-        val duration = durationData.toLong() * 1000
+        var (rotation, bitrate, duration) = try {
+            Triple(rotationData.toInt(), bitrateData.toInt(), durationData.toLong() * 1000)
+        } catch (e: java.lang.Exception) {
+            return@withContext Result(
+                index,
+                success = false,
+                failureMessage = "Failed to extract video meta-data, please try again"
+            )
+        }
 
         // Check for a min video bitrate before compression
         // Note: this is an experimental value


### PR DESCRIPTION
One of these 3 data points had the string: "9223372036854775807" in one of our crash reports. That's all we know. 