### PR TITLE
Force compressing code to run in IO thread

### DIFF
--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/VideoCompressor.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/VideoCompressor.kt
@@ -108,7 +108,7 @@ object VideoCompressor : CoroutineScope by MainScope() {
         var streamableFile: File? = null
         for (i in uris.indices) {
 
-            job = launch {
+            job = launch(Dispatchers.IO) {
 
                 val job = async { getMediaPath(context, uris[i]) }
                 val path = job.await()


### PR DESCRIPTION
Firebase crashlytics reported that there's some ANR happens because of some block of code running in the main thread
After Investigation, I found that the compressing library code uses EmptyCoroutineContext which is considered the app main thread
This PR has small fix for this issue by providing the IO context for kotlin coroutines to force code to be run in the IO thread