### PR TITLE
fix: update error handling for videoCompression to handle errors other than IllegalArgumentException in compressVideo

### DIFF
--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
@@ -58,7 +58,7 @@ object Compressor {
 
         try {
             mediaMetadataRetriever.setDataSource(context, srcUri)
-        } catch (exception: IllegalArgumentException) {
+        } catch (exception: Exception) {
             printException(exception)
             return@withContext Result(
                 index,


### PR DESCRIPTION
I encountered an issue when trying to run the `compressVideo` on a file that is corrupted or a file that is not a video file, but has the extension of the video file. Example: "test.jpg" > "test.mp4"