### PR TITLE
Replace videoWidth, videoHeight with VideoResizer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ when {
 }
 ```
 
-You can as well pass custom videoHeight, videoWidth, and videoBitrate values if you don't want the library to auto-generate the values for you. **The compression will fail if height or width is specified without the other, so ensure you pass both values**.
+You can as well pass custom resizer and videoBitrate values if you don't want the library to auto-generate the values for you.
 
 These values were tested on a huge set of videos and worked fine and fast with them. They might be changed based on the project needs and expectations.
 
@@ -136,11 +136,7 @@ or retrieve information about the original uri/file.
 
 - disableAudio: true/false to generate a video without audio. False by default.
 
-- keepOriginalResolution: true/false to tell the library not to change the resolution.
-
-- videoWidth: custom video width.
-
-- videoHeight: custom video height.
+- resizer: Function to resize the video dimensions. `VideoResizer.auto` by default.
 
 ### AppSpecificStorageConfiguration Configuration values
 
@@ -176,9 +172,7 @@ VideoCompressor.start(
       isMinBitrateCheckEnabled = true,
       videoBitrateInMbps = 5, /*Int, ignore, or null*/
       disableAudio = false, /*Boolean, or ignore*/
-      keepOriginalResolution = false, /*Boolean, or ignore*/
-      videoWidth = 360.0, /*Double, ignore, or null*/
-      videoHeight = 480.0 /*Double, ignore, or null*/
+      resizer = VideoResizer.matchSize(360, 480) /*VideoResizer, ignore, or null*/
    ),
    listener = object : CompressionListener {
        override fun onProgress(index: Int, percent: Float) {

--- a/app/src/main/java/com/abedelazizshe/lightcompressor/MainActivity.kt
+++ b/app/src/main/java/com/abedelazizshe/lightcompressor/MainActivity.kt
@@ -23,6 +23,7 @@ import com.abedelazizshe.lightcompressorlibrary.CompressionListener
 import com.abedelazizshe.lightcompressorlibrary.VideoCompressor
 import com.abedelazizshe.lightcompressorlibrary.VideoQuality
 import com.abedelazizshe.lightcompressorlibrary.config.Configuration
+import com.abedelazizshe.lightcompressorlibrary.config.VideoResizer
 import com.abedelazizshe.lightcompressorlibrary.config.SaveLocation
 import com.abedelazizshe.lightcompressorlibrary.config.SharedStorageConfiguration
 import kotlinx.coroutines.launch
@@ -190,6 +191,7 @@ class MainActivity : AppCompatActivity() {
                     quality = VideoQuality.LOW,
                     videoNames = uris.map { uri -> uri.pathSegments.last() },
                     isMinBitrateCheckEnabled = true,
+                    resizer = VideoResizer.limitSize(1280)
                 ),
                 listener = object : CompressionListener {
                     override fun onProgress(index: Int, percent: Float) {

--- a/app/src/main/java/com/abedelazizshe/lightcompressor/MainActivity.kt
+++ b/app/src/main/java/com/abedelazizshe/lightcompressor/MainActivity.kt
@@ -191,7 +191,7 @@ class MainActivity : AppCompatActivity() {
                     quality = VideoQuality.LOW,
                     videoNames = uris.map { uri -> uri.pathSegments.last() },
                     isMinBitrateCheckEnabled = true,
-                    resizer = VideoResizer.limitSize(1280)
+                    resizer = VideoResizer.limitSize(1280.0)
                 ),
                 listener = object : CompressionListener {
                     override fun onProgress(index: Int, percent: Float) {

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
@@ -16,6 +16,7 @@ import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.printExcep
 import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.setOutputFileParameters
 import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.setUpMP4Movie
 import com.abedelazizshe.lightcompressorlibrary.utils.StreamableVideo
+import com.abedelazizshe.lightcompressorlibrary.utils.roundDimension
 import com.abedelazizshe.lightcompressorlibrary.video.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -114,10 +115,10 @@ object Compressor {
             else configuration.videoBitrateInMbps!! * 1000000
 
         //Handle new width and height values
-        val resizer = configuration.resizer;
-        val target = resizer?.resize(width, height) ?: Pair(width, height);
-        var newWidth = target.first.toInt();
-        var newHeight = target.second.toInt();
+        val resizer = configuration.resizer
+        val target = resizer?.resize(width, height) ?: Pair(width, height)
+        var newWidth = roundDimension(target.first)
+        var newHeight = roundDimension(target.second)
 
         //Handle rotation values and swapping height and width if needed
         rotation = when (rotation) {

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/compressor/Compressor.kt
@@ -8,7 +8,6 @@ import android.util.Log
 import com.abedelazizshe.lightcompressorlibrary.CompressionProgressListener
 import com.abedelazizshe.lightcompressorlibrary.config.Configuration
 import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.findTrack
-import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.generateWidthAndHeight
 import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.getBitrate
 import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.hasQTI
 import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils.prepareVideoHeight
@@ -115,15 +114,10 @@ object Compressor {
             else configuration.videoBitrateInMbps!! * 1000000
 
         //Handle new width and height values
-        var (newWidth, newHeight) = if (configuration.videoHeight != null) Pair(
-            configuration.videoWidth?.toInt(),
-            configuration.videoHeight?.toInt()
-        )
-        else generateWidthAndHeight(
-            width,
-            height,
-            configuration.keepOriginalResolution
-        )
+        val resizer = configuration.resizer;
+        val target = resizer?.resize(width, height) ?: Pair(width, height);
+        var newWidth = target.first.toInt();
+        var newHeight = target.second.toInt();
 
         //Handle rotation values and swapping height and width if needed
         rotation = when (rotation) {
@@ -140,8 +134,8 @@ object Compressor {
 
         return@withContext start(
             index,
-            newWidth!!,
-            newHeight!!,
+            newWidth,
+            newHeight,
             destination,
             newBitrate,
             streamableFile,

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/Configuration.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/Configuration.kt
@@ -9,7 +9,36 @@ data class Configuration(
     var disableAudio: Boolean = false,
     val resizer: VideoResizer? = VideoResizer.auto,
     var videoNames: List<String>
-)
+) {
+    @Deprecated("Use VideoResizer to override the output video dimensions.", ReplaceWith("Configuration(quality, isMinBitrateCheckEnabled, videoBitrateInMbps, disableAudio, resizer = if (keepOriginalResolution) null else VideoResizer.auto, videoNames)"))
+    constructor(
+        quality: VideoQuality = VideoQuality.MEDIUM,
+        isMinBitrateCheckEnabled: Boolean = true,
+        videoBitrateInMbps: Int? = null,
+        disableAudio: Boolean = false,
+        keepOriginalResolution: Boolean,
+        videoNames: List<String>) : this(quality, isMinBitrateCheckEnabled, videoBitrateInMbps, disableAudio, getVideoResizer(keepOriginalResolution, null, null), videoNames)
+
+    @Deprecated("Use VideoResizer to override the output video dimensions.", ReplaceWith("Configuration(quality, isMinBitrateCheckEnabled, videoBitrateInMbps, disableAudio, resizer = VideoResizer.matchSize(videoWidth, videoHeight), videoNames)"))
+    constructor(
+        quality: VideoQuality = VideoQuality.MEDIUM,
+        isMinBitrateCheckEnabled: Boolean = true,
+        videoBitrateInMbps: Int? = null,
+        disableAudio: Boolean = false,
+        keepOriginalResolution: Boolean = false,
+        videoHeight: Double? = null,
+        videoWidth: Double? = null,
+        videoNames: List<String>) : this(quality, isMinBitrateCheckEnabled, videoBitrateInMbps, disableAudio, getVideoResizer(keepOriginalResolution, videoWidth, videoHeight), videoNames)
+}
+
+private fun getVideoResizer(keepOriginalResolution: Boolean, videoHeight: Double?, videoWidth: Double?): VideoResizer? =
+    if (keepOriginalResolution) {
+        null
+    } else if (videoWidth != null && videoHeight != null) {
+        VideoResizer.matchSize(videoWidth, videoHeight, true)
+    } else {
+        VideoResizer.auto
+    }
 
 data class AppSpecificStorageConfiguration(
     var subFolderName: String? = null,

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/Configuration.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/Configuration.kt
@@ -7,9 +7,7 @@ data class Configuration(
     var isMinBitrateCheckEnabled: Boolean = true,
     var videoBitrateInMbps: Int? = null,
     var disableAudio: Boolean = false,
-    val keepOriginalResolution: Boolean = false,
-    var videoHeight: Double? = null,
-    var videoWidth: Double? = null,
+    val resizer: VideoResizer? = VideoResizer.auto,
     var videoNames: List<String>
 )
 

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/Configuration.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/Configuration.kt
@@ -28,7 +28,7 @@ data class Configuration(
         keepOriginalResolution: Boolean = false,
         videoHeight: Double? = null,
         videoWidth: Double? = null,
-        videoNames: List<String>) : this(quality, isMinBitrateCheckEnabled, videoBitrateInMbps, disableAudio, getVideoResizer(keepOriginalResolution, videoWidth, videoHeight), videoNames)
+        videoNames: List<String>) : this(quality, isMinBitrateCheckEnabled, videoBitrateInMbps, disableAudio, getVideoResizer(keepOriginalResolution, videoHeight, videoWidth), videoNames)
 }
 
 private fun getVideoResizer(keepOriginalResolution: Boolean, videoHeight: Double?, videoWidth: Double?): VideoResizer? =

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/VideoResizer.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/VideoResizer.kt
@@ -25,7 +25,7 @@ fun interface VideoResizer {
          * @param limit The maximum width and height of the video
          */
         @JvmStatic
-        fun limitSize(limit: Int): VideoResizer = LimitDimension(limit, limit)
+        fun limitSize(limit: Double): VideoResizer = LimitDimension(limit, limit)
 
         /**
          * Scale the video down if the width or height are greater than [maxWidth] or [maxHeight], retaining the video's aspect ratio.
@@ -33,14 +33,14 @@ fun interface VideoResizer {
          * @param maxHeight The maximum height of the video
          */
         @JvmStatic
-        fun limitSize(maxWidth: Int, maxHeight: Int): VideoResizer = LimitDimension(maxWidth, maxHeight)
+        fun limitSize(maxWidth: Double, maxHeight: Double): VideoResizer = LimitDimension(maxWidth, maxHeight)
 
         /**
          * Scales the video so that the width and height matches [size], retaining the video's aspect ratio.
          * @param size The target width/height of the video
          */
         @JvmStatic
-        fun matchSize(size: Int, stretch: Boolean = false): VideoResizer = MatchDimension(size, size, stretch)
+        fun matchSize(size: Double, stretch: Boolean = false): VideoResizer = MatchDimension(size, size, stretch)
 
         /**
          * Scales the video so that the width matches [width] or the height matches [height], retaining the video's aspect ratio.
@@ -48,7 +48,7 @@ fun interface VideoResizer {
          * @param height The target height of the video
          */
         @JvmStatic
-        fun matchSize(width: Int, height: Int, stretch: Boolean = false): VideoResizer = MatchDimension(width, height, stretch)
+        fun matchSize(width: Double, height: Double, stretch: Boolean = false): VideoResizer = MatchDimension(width, height, stretch)
 
         private fun keepAspect(width: Double, height: Double, newWidth: Double, newHeight: Double): Pair<Double, Double> {
             val desiredAspect = width / height
@@ -59,21 +59,15 @@ fun interface VideoResizer {
 
     fun resize(width: Double, height: Double): Pair<Double, Double>
 
-    private class LimitDimension(private val width: Int, private val height: Int) : VideoResizer {
+    private class LimitDimension(private val width: Double, private val height: Double) : VideoResizer {
         override fun resize(width: Double, height: Double): Pair<Double, Double> {
-            val newWidth = this.width.toDouble()
-            val newHeight = this.height.toDouble()
-
-            return if (width < newWidth && height < newHeight) Pair(width, height) else keepAspect(width, height, newWidth, newHeight)
+            return if (width < this.width && height < this.height) Pair(width, height) else keepAspect(width, height, this.width, this.height)
         }
     }
 
-    private class MatchDimension(private val width: Int, private val height: Int, private val stretch: Boolean) : VideoResizer {
+    private class MatchDimension(private val width: Double, private val height: Double, private val stretch: Boolean) : VideoResizer {
         override fun resize(width: Double, height: Double): Pair<Double, Double> {
-            var newWidth = this.width.toDouble()
-            var newHeight = this.height.toDouble()
-
-            return if (stretch) Pair(newWidth, newHeight) else keepAspect(width, height, newWidth, newHeight)
+            return if (stretch) Pair(this.width, this.height) else keepAspect(width, height, this.width, this.height)
         }
     }
 

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/VideoResizer.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/VideoResizer.kt
@@ -1,0 +1,48 @@
+package com.abedelazizshe.lightcompressorlibrary.config
+
+import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils
+
+fun interface VideoResizer {
+    companion object {
+        @JvmStatic
+        val auto: VideoResizer = ScaleResize(null);
+
+        @JvmStatic
+        fun scale(value: Double): VideoResizer = ScaleResize(value)
+
+        @JvmStatic
+        fun limitSize(limit: Int): VideoResizer = TargetDimension(limit, limit, false)
+
+        @JvmStatic
+        fun limitSize(maxWidth: Int, maxHeight: Int): VideoResizer = TargetDimension(maxWidth, maxHeight, false)
+
+        @JvmStatic
+        fun matchSize(size: Int): VideoResizer = TargetDimension(size, size, true)
+
+        @JvmStatic
+        fun matchSize(width: Int, height: Int): VideoResizer = TargetDimension(width, height, true)
+    }
+
+    fun resize(width: Double, height: Double): Pair<Double, Double>
+
+    private class TargetDimension(private val width: Int, private val height: Int, private val scaleUp: Boolean = false) : VideoResizer {
+        override fun resize(width: Double, height: Double): Pair<Double, Double> {
+            var newWidth = this.width.toDouble()
+            var newHeight = this.height.toDouble()
+
+            if (!scaleUp && width < newWidth && height < newHeight)
+                return Pair(width, height);
+
+            val desiredAspect = width / height
+            val videoAspect = newWidth / newHeight
+            return if (videoAspect <= desiredAspect) Pair(newWidth, newWidth / desiredAspect) else Pair(newHeight * desiredAspect, newHeight)
+        }
+    }
+
+    private class ScaleResize(private val percentage: Double? = null) : VideoResizer {
+        override fun resize(width: Double, height: Double): Pair<Double, Double> {
+            val p = percentage ?: CompressorUtils.autoResizePercentage(width, height)
+            return Pair(width * p, height * p)
+        }
+    }
+}

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/VideoResizer.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/config/VideoResizer.kt
@@ -4,21 +4,49 @@ import com.abedelazizshe.lightcompressorlibrary.utils.CompressorUtils
 
 fun interface VideoResizer {
     companion object {
+        /**
+         * Shrinks the video's resolution based on its original width and height.
+         * - 50% If the width or height is greater than or equal to 1920 pixels.
+         * - 75% If the width or height is greater than or equal to 1280 pixels.
+         * - 95% If the width or height is greater than or equal to 960 pixels.
+         * - 90% If the width and height are both less than 960 pixels.
+         */
         @JvmStatic
         val auto: VideoResizer = ScaleResize(null);
 
+        /**
+         * Resize the video dimensions by the given scale factor
+         */
         @JvmStatic
         fun scale(value: Double): VideoResizer = ScaleResize(value)
 
+        /**
+         * Scale the video down if the width or height are greater than [limit], retaining the video's aspect ratio.
+         * @param limit The maximum width and height of the video
+         */
         @JvmStatic
         fun limitSize(limit: Int): VideoResizer = LimitDimension(limit, limit)
 
+        /**
+         * Scale the video down if the width or height are greater than [maxWidth] or [maxHeight], retaining the video's aspect ratio.
+         * @param maxWidth The maximum width of the video
+         * @param maxHeight The maximum height of the video
+         */
         @JvmStatic
         fun limitSize(maxWidth: Int, maxHeight: Int): VideoResizer = LimitDimension(maxWidth, maxHeight)
 
+        /**
+         * Scales the video so that the width and height matches [size], retaining the video's aspect ratio.
+         * @param size The target width/height of the video
+         */
         @JvmStatic
         fun matchSize(size: Int, stretch: Boolean = false): VideoResizer = MatchDimension(size, size, stretch)
 
+        /**
+         * Scales the video so that the width matches [width] or the height matches [height], retaining the video's aspect ratio.
+         * @param width The target width of the video
+         * @param height The target height of the video
+         */
         @JvmStatic
         fun matchSize(width: Int, height: Int, stretch: Boolean = false): VideoResizer = MatchDimension(width, height, stretch)
 

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/utils/CompressorUtils.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/utils/CompressorUtils.kt
@@ -195,44 +195,15 @@ object CompressorUtils {
      * Generate new width and height for source file
      * @param width file's original width
      * @param height file's original height
-     * @return new width and height pair
+     * @return the scale factor to apply to the video's resolution
      */
-    fun generateWidthAndHeight(
-        width: Double,
-        height: Double,
-        keepOriginalResolution: Boolean,
-    ): Pair<Int, Int> {
-
-        if (keepOriginalResolution) {
-            return Pair(width.roundToInt(), height.roundToInt())
+    fun autoResizePercentage(width: Double, height: Double): Double {
+        return when {
+            width >= 1920 || height >= 1920 -> 0.5
+            width >= 1280 || height >= 1280 -> 0.75
+            width >= 960 || height >= 960 -> 0.95
+            else -> 0.9
         }
-
-        val newWidth: Int
-        val newHeight: Int
-
-        when {
-            width >= 1920 || height >= 1920 -> {
-                newWidth = generateWidthHeightValue(width, 0.5)
-                newHeight = generateWidthHeightValue(height, 0.5)
-            }
-
-            width >= 1280 || height >= 1280 -> {
-                newWidth = generateWidthHeightValue(width, 0.75)
-                newHeight = generateWidthHeightValue(height, 0.75)
-            }
-
-            width >= 960 || height >= 960 -> {
-                newWidth = generateWidthHeightValue(width, 0.95)
-                newHeight = generateWidthHeightValue(height, 0.95)
-            }
-
-            else -> {
-                newWidth = generateWidthHeightValue(width, 0.9)
-                newHeight = generateWidthHeightValue(height, 0.9)
-            }
-        }
-
-        return Pair(newWidth, newHeight)
     }
 
     fun hasQTI(): Boolean {

--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/utils/NumbersUtils.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/utils/NumbersUtils.kt
@@ -28,5 +28,5 @@ fun uInt32ToInt(uInt32: Int): Int {
 
 private fun roundEven(value: Int): Int = value + 1 and 1.inv()
 
-fun generateWidthHeightValue(value: Double, factor: Double): Int =
-    roundEven((((value * factor) / 16).roundToInt() * 16))
+fun roundDimension(value: Double): Int =
+    roundEven(((value / 16).roundToInt() * 16))


### PR DESCRIPTION
I'm using this library and wanted to set a maximum resolution for videos however that is currently not possible. When overriding the default resize function by adding `videoWidth` and `videoHeight` to the configuration, this resizes the video to those dimensions exactly. In my case this means that the video is stretched to a 1:1 aspect ratio, and lower resolution videos are upscaled.

I've added a functional interface `VideoResizer` that allows a custom function to calculate the desired dimension using the source video's dimensions, with some default implementations:
- `VideoResizer.auto` - Matches the original behavior when not providing `videoWidth` and `videoHeight` in the configuration
- `VideoResizer.scale` - Scale the dimensions by a scale factor
- `VideoResizer.limitSize` - Set a maximum width and height value for the video
- `VideoResizer.matchSize` - Set an exact width and height value

I've updated the `Configuration` class and replaced `keepOriginalResolution`, `videoWidth` and `videoHeight` with `resizer`, and added a constructor overload to match the old behaviour.