### PR TITLE
Changed minSdkVersion to 21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.abedelazizshe.lightcompressor"
-        minSdkVersion 24
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0.0"

--- a/lightcompressor/build.gradle
+++ b/lightcompressor/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven-publish'
 android {
     compileSdkVersion 33
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 21
         targetSdkVersion 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
`minSdkVersion` was changed from 21 to 24 in [release 1.3.0](https://github.com/AbedElazizShe/LightCompressor/releases/tag/1.3.0). What is the reason for this change? We want to use this library, but we need to support API from version 21.