### PR TITLE
Handle exception inside coroutine

### DIFF
--- a/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/VideoCompressor.kt
+++ b/lightcompressor/src/main/java/com/abedelazizshe/lightcompressorlibrary/VideoCompressor.kt
@@ -108,7 +108,12 @@ object VideoCompressor : CoroutineScope by MainScope() {
         var streamableFile: File? = null
         for (i in uris.indices) {
 
-            job = launch(Dispatchers.IO) {
+            val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+                listener.onFailure(i, throwable.message ?: "")
+            }
+            val coroutineScope = CoroutineScope(Job() + coroutineExceptionHandler)
+
+            job = coroutineScope.launch(Dispatchers.IO) {
 
                 val job = async { getMediaPath(context, uris[i]) }
                 val path = job.await()


### PR DESCRIPTION
Got unhandled exception when device run out of storage.

How to reproduce
1. fill your device storage until has zero left mb of storage (https://play.google.com/store/apps/details?id=com.arumcomm.fillstorage)
2. run the sample app

Exception Evidence
<img width="1400" alt="image" src="https://github.com/AbedElazizShe/LightCompressor/assets/25836733/be23f53a-1060-44a2-aa68-eabe779415b4">
<img width="928" alt="Screenshot 2024-04-24 at 15 55 27" src="https://github.com/AbedElazizShe/LightCompressor/assets/25836733/b88543b5-909c-448d-92b7-419753a0e66a">
